### PR TITLE
fix chrome sorting bug

### DIFF
--- a/src/classes/colorGenerator.js
+++ b/src/classes/colorGenerator.js
@@ -46,7 +46,7 @@ class ColorGenerator{
             shades.push({"hue": hsv.hue, "saturation": hsv.saturation, "value": value});
         }
 
-        shades.sort((a, b) => {return a.value > b.value});
+        shades.sort((a, b) => {return a.value - b.value});
 
         const toneI = hsv.saturation / (toneA + 1);
         for(let i = 0; i < toneA; i++){
@@ -55,7 +55,7 @@ class ColorGenerator{
             tones.push({"hue": hsv.hue, "saturation": saturation, "value": hsv.value});
         }
 
-        tones.sort((a, b) => {return a.saturation < b.saturation});
+        tones.sort((a, b) => {return b.saturation - a.saturation});
 
         return{shades, tones};
     }


### PR DESCRIPTION
Webkit also seems to work for me. #21
Javascript array.sort takes in a sort function that should return a number - negative for <, 0 for ==, positive for >. The original code returns a bool, which translates to 0 or 1, ie only == or >, never <.

https://stackoverflow.com/a/48082262
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort